### PR TITLE
Make the plugin work with the older bootstrap version

### DIFF
--- a/gratatouille-gradle-plugin/api/gratatouille-gradle-plugin.api
+++ b/gratatouille-gradle-plugin/api/gratatouille-gradle-plugin.api
@@ -34,43 +34,31 @@ public abstract class gratatouille/gradle/DefaultGratatouilleWiringExtension : g
 	public fun pluginMarker (Ljava/lang/String;Ljava/lang/String;)V
 }
 
-public abstract class gratatouille/gradle/Gratatouille1Plugin : org/gradle/api/Plugin {
-	public fun <init> ()V
-	public synthetic fun apply (Ljava/lang/Object;)V
-	public fun apply (Lorg/gradle/api/Project;)V
-}
-
-public final class gratatouille/gradle/Gratatouille1PluginKt {
-	public static final fun getGratatouille1 (Lorg/gradle/api/Project;)Lgratatouille/gradle/Gratatouille1Plugin;
-}
-
-public abstract class gratatouille/gradle/Gratatouille2Plugin : org/gradle/api/Plugin {
-	public fun <init> ()V
-	public synthetic fun apply (Ljava/lang/Object;)V
-	public fun apply (Lorg/gradle/api/Project;)V
-}
-
-public final class gratatouille/gradle/Gratatouille2PluginKt {
-	public static final fun getGratatouille2 (Lorg/gradle/api/Project;)Lgratatouille/gradle/Gratatouille2Plugin;
+public final class gratatouille/gradle/ExtensionsKt {
+	public static final fun plugin (Lorg/gradle/api/Project;)V
+	public static final fun tasksPlugin (Lorg/gradle/api/Project;)V
+	public static final fun wiringPlugin (Lorg/gradle/api/Project;)V
 }
 
 public abstract interface class gratatouille/gradle/GratatouilleExtension : gratatouille/gradle/CodeGeneratorExtension, gratatouille/gradle/WiringExtension {
-}
-
-public abstract class gratatouille/gradle/GratatouillePlugin : org/gradle/api/Plugin {
-	public fun <init> ()V
-	public synthetic fun apply (Ljava/lang/Object;)V
-	public fun apply (Lorg/gradle/api/Project;)V
-}
-
-public final class gratatouille/gradle/GratatouillePluginKt {
-	public static final fun getGratatouille (Lorg/gradle/api/Project;)Lgratatouille/gradle/GratatouillePlugin;
 }
 
 public abstract interface class gratatouille/gradle/GratatouilleTasksExtension : gratatouille/gradle/CodeGeneratorExtension {
 }
 
 public abstract interface class gratatouille/gradle/GratatouilleWiringExtension : gratatouille/gradle/CodeGeneratorExtension, gratatouille/gradle/WiringExtension {
+}
+
+public abstract class gratatouille/gradle/PluginPlugin : org/gradle/api/Plugin {
+	public fun <init> ()V
+	public synthetic fun apply (Ljava/lang/Object;)V
+	public fun apply (Lorg/gradle/api/Project;)V
+}
+
+public abstract class gratatouille/gradle/TasksPluginPlugin : org/gradle/api/Plugin {
+	public fun <init> ()V
+	public synthetic fun apply (Ljava/lang/Object;)V
+	public fun apply (Lorg/gradle/api/Project;)V
 }
 
 public final class gratatouille/gradle/VersionKt {
@@ -81,6 +69,12 @@ public abstract interface class gratatouille/gradle/WiringExtension {
 	public abstract fun pluginDescriptor (Ljava/lang/String;Ljava/lang/String;)V
 	public abstract fun pluginMarker (Ljava/lang/String;)V
 	public abstract fun pluginMarker (Ljava/lang/String;Ljava/lang/String;)V
+}
+
+public abstract class gratatouille/gradle/WiringPluginPlugin : org/gradle/api/Plugin {
+	public fun <init> ()V
+	public synthetic fun apply (Ljava/lang/Object;)V
+	public fun apply (Lorg/gradle/api/Project;)V
 }
 
 public final class gratatouille/gradle/internal/DefaultCodeGenerationSpec : gratatouille/gradle/CodeGenerationSpec {

--- a/gratatouille-gradle-plugin/build.gradle.kts
+++ b/gratatouille-gradle-plugin/build.gradle.kts
@@ -26,8 +26,8 @@ buildConfig {
 
 gratatouille {
     pluginMarker("com.gradleup.gratatouille")
-//    pluginMarker("com.gradleup.gratatouille.tasks")
-//    pluginMarker("com.gradleup.gratatouille.wiring")
+    pluginMarker("com.gradleup.gratatouille.tasks", "default")
+    pluginMarker("com.gradleup.gratatouille.wiring", "default")
     codeGeneration()
 }
 

--- a/gratatouille-gradle-plugin/src/main/kotlin/gratatouille/gradle/extensions.kt
+++ b/gratatouille-gradle-plugin/src/main/kotlin/gratatouille/gradle/extensions.kt
@@ -1,6 +1,7 @@
 package gratatouille.gradle
 
 import gratatouille.GExtension
+import gratatouille.GPlugin
 import gratatouille.gradle.internal.PluginVariant
 import gratatouille.gradle.internal.USAGE_GRATATOUILLE
 import gratatouille.gradle.internal.codeGeneration
@@ -56,7 +57,11 @@ interface WiringExtension {
 
 interface GratatouilleExtension: CodeGeneratorExtension, WiringExtension
 
-@GExtension("com.gradleup.gratatouille", "gratatouille",)
+@GPlugin("com.gradleup.gratatouille")
+fun plugin(project: Project) {
+  project.extensions.create(GratatouilleExtension::class.java, "gratatouille", DefaultGratatouilleExtension::class.java, project)
+}
+
 abstract class DefaultGratatouilleExtension(private val project: Project): GratatouilleExtension {
   init {
     project.configureDefaultVersionsResolutionStrategy()
@@ -85,7 +90,11 @@ abstract class DefaultGratatouilleExtension(private val project: Project): Grata
 
 interface GratatouilleWiringExtension: CodeGeneratorExtension, WiringExtension
 
-@GExtension("com.gradleup.gratatouille.wiring", "gratatouille1",)
+@GPlugin("com.gradleup.gratatouille.wiring")
+fun wiringPlugin(project: Project) {
+  project.extensions.create(GratatouilleWiringExtension::class.java, "gratatouille", DefaultGratatouilleWiringExtension::class.java, project)
+}
+
 abstract class DefaultGratatouilleWiringExtension(private val project: Project): GratatouilleWiringExtension {
 
   init {
@@ -130,7 +139,11 @@ abstract class DefaultGratatouilleWiringExtension(private val project: Project):
 
 interface GratatouilleTasksExtension: CodeGeneratorExtension
 
-@GExtension("com.gradleup.gratatouille.tasks", "gratatouille2",)
+@GPlugin("com.gradleup.gratatouille.tasks")
+fun tasksPlugin(project: Project) {
+  project.extensions.create(GratatouilleTasksExtension::class.java, "gratatouille", DefaultGratatouilleTasksExtension::class.java, project)
+}
+
 abstract class DefaultGratatouilleTasksExtension(private val project: Project): GratatouilleTasksExtension {
   init {
     project.configureDefaultVersionsResolutionStrategy()

--- a/test-plugin-isolated/gradle-plugin/build.gradle.kts
+++ b/test-plugin-isolated/gradle-plugin/build.gradle.kts
@@ -33,7 +33,7 @@ dependencies {
 }
 
 
-gratatouille1 {
+gratatouille {
     pluginMarker("testplugin.isolated", "default")
     codeGeneration()
 }

--- a/test-plugin-isolated/gradle-tasks/build.gradle.kts
+++ b/test-plugin-isolated/gradle-tasks/build.gradle.kts
@@ -26,7 +26,7 @@ dependencies {
     implementation(libs.okio)
 }
 
-gratatouille2 {
+gratatouille {
     codeGeneration {
         classLoaderIsolation()
     }


### PR DESCRIPTION
* Create all 3 plugin markers
* Use `@GPlugin` to allow having different extension types sharing the same extension name.