### PR TITLE
Filter out directories from `GInputFiles`

### DIFF
--- a/gratatouille-processor/src/main/kotlin/gratatouille/processor/codegen/Task.kt
+++ b/gratatouille-processor/src/main/kotlin/gratatouille/processor/codegen/Task.kt
@@ -134,7 +134,7 @@ private fun IrTask.register(): FunSpec {
               properties.inputs.forEach {
                 when (it.type) {
                   is InputFiles, Classpath -> {
-                    add("it.%L.from(%L)\n", it.name, it.name)
+                    add("it.%L.from(%L.filter { it.isFile })\n", it.name, it.name)
                   }
 
                   else -> {


### PR DESCRIPTION
See https://mbonnin.net/2025-01-22_input_directory_is_a_lie/

I don't really see a use case for snapshotting the directories. Until someone comes up with a clear use case, filter them out.