### PR TITLE
Revert "Remove group and description (#69)"

### DIFF
--- a/gratatouille-processor/src/main/kotlin/gratatouille/processor/codegen/Task.kt
+++ b/gratatouille-processor/src/main/kotlin/gratatouille/processor/codegen/Task.kt
@@ -38,6 +38,16 @@ private fun IrTask.register(): FunSpec {
         .build()
     )
     .addParameter(
+      ParameterSpec.builder(taskDescription, ClassName("kotlin", "String").copy(nullable = true))
+        .defaultValue(description.toCodeBlock())
+        .build()
+    )
+    .addParameter(
+      ParameterSpec.builder(taskGroup, ClassName("kotlin", "String").copy(nullable = true))
+        .defaultValue(group.toCodeBlock())
+        .build()
+    )
+    .addParameter(
       ParameterSpec.builder(extraClasspath, ClassName("org.gradle.api.file", "FileCollection").copy(nullable = true))
         .defaultValue("null")
         .build()
@@ -77,6 +87,8 @@ private fun IrTask.register(): FunSpec {
 
         add("return tasks.register(${taskName},%T::class.java) {\n", taskClassName())
         withIndent {
+          add("it.group = ${taskGroup}\n")
+          add("it.description = ${taskDescription}\n")
           if (isolationOptions != null) {
             add("it.${classpath}.from(configuration)\n")
           }

--- a/gratatouille-tasks-runtime/api/gratatouille-tasks-runtime.api
+++ b/gratatouille-tasks-runtime/api/gratatouille-tasks-runtime.api
@@ -32,6 +32,8 @@ public abstract interface annotation class gratatouille/tasks/GManuallyWired : j
 }
 
 public abstract interface annotation class gratatouille/tasks/GTask : java/lang/annotation/Annotation {
+	public abstract fun description ()Ljava/lang/String;
+	public abstract fun group ()Ljava/lang/String;
 	public abstract fun name ()Ljava/lang/String;
 	public abstract fun pure ()Z
 }

--- a/gratatouille-tasks-runtime/src/main/kotlin/gratatouille/tasks/api.kt
+++ b/gratatouille-tasks-runtime/src/main/kotlin/gratatouille/tasks/api.kt
@@ -57,12 +57,14 @@ import java.io.File
  * ```
  *
  * @param name the name of the task. If empty, defaults to the name of the function.
+ * @param group the group of the task. If empty, defaults to no group. Tasks without a group are not displayed in `./gradlew --tasks` by default.
+ * @param description the description of the task. If empty, defaults to no description.
  * @param pure whether the annotated function is [pure](https://en.wikipedia.org/wiki/Pure_function), i.e. its outputs only depends
  * on the inputs. Impure functions are marked as non-cacheable and never [up-to-date](https://docs.gradle.org/current/userguide/incremental_build.html).
  */
 @Target(AnnotationTarget.FUNCTION)
 @Retention(AnnotationRetention.SOURCE)
-annotation class GTask(val name: String = "", val pure: Boolean = true)
+annotation class GTask(val name: String = "", val group: String = "", val description: String = "", val pure: Boolean = true)
 
 /**
  * Indicates that the given parameter doesn't contribute snapshotting and should be marked `Internal`.


### PR DESCRIPTION
This reverts commit 907e08d6a0b673cfd6c2ff7cadb548362e636cb7.

I changed my mind. In most cases, `registerFooTask()` is everything that's needed to register a new task. Having to call `.configure()` after that is not fun.

See #69 
