### PR TITLE
Allocate a new BuildService name since the package name changed

### DIFF
--- a/gratatouille-processor/src/main/kotlin/gratatouille/processor/codegen/Task.kt
+++ b/gratatouille-processor/src/main/kotlin/gratatouille/processor/codegen/Task.kt
@@ -87,7 +87,8 @@ private fun IrTask.register(): FunSpec {
           }
           add("}\n")
           add(
-            "gradle.sharedServices.registerIfAbsent(\"gratatouille\", %T::class.java) {}\n",
+            "gradle.sharedServices.registerIfAbsent(%S, %T::class.java) {}\n",
+            gratatouilleBuildServiceName,
             ClassName(gratatouilleWiringPackageName, "GratatouilleBuildService")
           )
         }
@@ -198,7 +199,7 @@ private fun IrTask.task(): TypeSpec {
             .addModifiers(KModifier.ABSTRACT)
             .addAnnotation(
               AnnotationSpec.builder(ClassName("org.gradle.api.services", "ServiceReference"))
-                .addMember("%S", "gratatouille")
+                .addMember("%S", gratatouilleBuildServiceName)
                 .build()
             )
             .returns(ClassName(gratatouilleWiringPackageName, "GratatouilleBuildService").toGradleProperty())

--- a/gratatouille-processor/src/main/kotlin/gratatouille/processor/names.kt
+++ b/gratatouille-processor/src/main/kotlin/gratatouille/processor/names.kt
@@ -7,7 +7,9 @@ internal val outputFile = "outputFile"
 internal val classpath = "classpath"
 internal val workerExecutor = "getWorkerExecutor"
 internal val extraClasspath = "extraClasspath"
-internal val gratatouilleBuildService = "gratatouilleBuildService2"
+internal val gratatouilleBuildService = "gratatouilleBuildService"
+// Bump this every time the BuildService class name changes
+internal val gratatouilleBuildServiceName = "gratatouille2"
 
 internal val gratatouilleWiringPackageName = "gratatouille"
 internal val gratatouilleTasksPackageName = "gratatouille.tasks"


### PR DESCRIPTION
This allows plugin built with Gratatouille < 0.2.0 to cohabit with plugins built with Gratatouille > 0.2.0